### PR TITLE
Support both openbabel 2 and 3

### DIFF
--- a/lbvs_consent.opam
+++ b/lbvs_consent.opam
@@ -30,6 +30,7 @@ depends: [
   "conf-openbabel"
   "conf-python-3"
   "conf-rdkit"
+  "conf-pkg-config"
 ]
 synopsis: "Chemoinformatics software for consensus fingerprint queries"
 description: """

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,9 @@
+CFLAGS := `pkg-config --silence-errors --cflags openbabel-2.0 || pkg-config --cflags openbabel-3`
+LDFLAGS := `pkg-config --silence-errors --libs openbabel-2.0 || pkg-config --libs openbabel-3`
+
 ob_maccs: ob_maccs.cpp
-	c++ -W -Wall -I/usr/include/openbabel-2.0 ob_maccs.cpp \
-	  -o lbvs_consent_ob_maccs -lopenbabel -Wl,-R/usr/lib
+	c++ -W -Wall $(CFLAGS) ob_maccs.cpp \
+	  -o lbvs_consent_ob_maccs $(LDFLAGS) -Wl,-R/usr/lib
 
 clean:
 	\rm -f lbvs_consent_ob_maccs


### PR DESCRIPTION
Currently openbabel-2.0 support is hardcoded in the Makefile's include directory, which makes the installation fail on systems offering openbabel-3.

This PR changes it to support openbabel 2 and 3 via `pkg-config` and https://github.com/ocaml/opam-repository/pull/24545. It therefore also adds a dependency on `conf-pkg-config`.