### PR TITLE
Add pkg bounds for cpm and batteries

### DIFF
--- a/lbvs_consent.opam
+++ b/lbvs_consent.opam
@@ -16,7 +16,7 @@ install: [
 depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "1.6"}
-  "batteries"
+  "batteries" {>= "3.0.0"}
   "bitv" {>= "1.2"}
   "parany" {>= "13.1.0"} # we need Parany.get_rank()
   "dolog" {>= "4.0.0"}

--- a/lbvs_consent.opam
+++ b/lbvs_consent.opam
@@ -23,7 +23,7 @@ depends: [
   "camlzip"
   "qcheck"
   "vpt"
-  "cpm"
+  "cpm" {>= "4.0.0"}
   "dokeysto"
   "minicli" {>= "5.0.0"}
   "conf-boost"


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/24677 I came across a couple of missing lower bounds:
- `cpm` seems to add a toplevel `Cpm` module with the 4.0.0 release
- `BatString.split_on_string` was added in batteries 3.0.0 [AFAICS](https://github.com/ocaml-batteries-team/batteries-included/issues/1122)

This PR thus adds them upstream, so we don't forget them :slightly_smiling_face: 