### PR TITLE
Add ocamlzip lower bound

### DIFF
--- a/lbvs_consent.opam
+++ b/lbvs_consent.opam
@@ -20,7 +20,7 @@ depends: [
   "bitv" {>= "1.2"}
   "parany" {>= "13.1.0"} # we need Parany.get_rank()
   "dolog" {>= "4.0.0"}
-  "camlzip"
+  "camlzip" {>= "1.06"}
   "qcheck"
   "vpt"
   "cpm" {>= "4.0.0"}


### PR DESCRIPTION
I spotted another lower bound: `Gzip.output_substring` was added in camlzip 1.06